### PR TITLE
fix: refine scorecard compatibility and platform fallback

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,16 @@ This plugin is built for writers who publish from Obsidian to WeChat Official Ac
 
 If this plugin saves you time when formatting, copying, or syncing WeChat articles, you can [support ongoing maintenance](./docs/support.md).
 
+## Privacy and permissions
+
+Wechat Converter does not include client-side telemetry and does not automatically upload your notes. Network access, local filesystem reads, and clipboard writes are used only when you explicitly run the related feature.
+
+- **Network access and `fetch()` calls**: WeChat draft sync calls the official WeChat API, custom API proxy settings call the proxy URL you configure, AI layout calls the AI Provider you configure, and multi-platform delivery connects to the local companion browser extension service.
+- **Local filesystem access**: The plugin reads local vault files only when processing images, covers, Mermaid exports, LaTeX exports, and other assets referenced by the current note.
+- **Clipboard access**: Copy actions write the current rendered article to the system clipboard so you can paste it into the WeChat editor or another publishing surface.
+- **Third-party accounts**: WeChat sync requires your own AppID and AppSecret. Other platforms are handled by the companion browser extension using the login state already present in your browser.
+- **Companion browser extension**: Multi-platform publishing and Pro licensing are coordinated with Obsidian Publisher. The Obsidian plugin keeps the writing, rendering, platform selection, and task handoff inside your vault.
+
 ## Big Update: Multi-platform Publishing
 
 Wechat Converter is no longer limited to WeChat Official Accounts. From the same `Publish & Distribute` window, you can send the current article to platforms such as Zhihu, Juejin, CSDN, Yuque, Xiaohongshu, and other targets supported by Obsidian Publisher.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,25 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Chrome Companion](https://img.shields.io/badge/Chrome%20%E5%8D%8F%E5%90%8C%E6%89%A9%E5%B1%95-Obsidian%20%E5%8F%91%E5%B8%83%E5%8A%A9%E6%89%8B%E2%80%A2%E5%8D%B3%E5%B0%86%E4%B8%8A%E6%9E%B6-7c3aed)
 
+## English overview
+
+WeChat Converter is an Obsidian plugin for writers who publish Markdown notes to WeChat Official Accounts and other Chinese content platforms. It provides live preview, WeChat-ready HTML conversion, rich HTML copy, WeChat draft sync, local image processing, math and diagram export, AI-assisted layout, and optional multi-platform draft delivery through the Obsidian Publisher companion browser extension.
+
+Full English documentation is available in [README.en.md](./README.en.md).
+
+### Privacy and permissions
+
+The plugin does not include client-side telemetry and does not automatically upload your notes. The following capabilities are used only when you explicitly run the related feature:
+
+- **Network access and `fetch()` calls**: WeChat draft sync calls the official WeChat API, custom API proxy settings call the proxy URL you configure, AI layout calls the AI Provider you configure, and multi-platform delivery connects to the local companion browser extension service.
+- **Local filesystem access**: The plugin reads local vault files only when processing images, covers, Mermaid exports, LaTeX exports, and other assets referenced by the current note.
+- **Clipboard access**: Copy actions write the current rendered article to the system clipboard so you can paste it into the WeChat editor or another publishing surface.
+- **Third-party accounts**: WeChat sync requires your own AppID and AppSecret. Other platforms are handled by the companion browser extension using the login state already present in your browser.
+- **Companion browser extension**: Multi-platform publishing and Pro licensing are coordinated with Obsidian Publisher. The Obsidian plugin keeps the writing, rendering, platform selection, and task handoff inside your vault.
 
 > 本项目基于开源项目 [ai-writing-plugins](https://github.com/Ceeon/ai-writing-plugins) 进行深度重构与迭代开发。我们致力于打造 Obsidian 生态中体验最好的公众号排版工具。
 
 如果这个插件帮你节省了公众号排版、复制或同步草稿箱的时间，欢迎[支持项目继续维护](./docs/support.md)。
-
-## English summary
-
-WeChat Converter is an Obsidian plugin for Chinese creators who publish Markdown notes to WeChat Official Accounts and other Chinese content platforms. It converts Markdown into WeChat-ready HTML, supports live preview, rich copy, WeChat draft sync, local image handling, LaTeX / Mermaid export, and optional multi-platform draft delivery through the companion browser extension.
-
-Privacy and permissions: the plugin has no client-side telemetry. Network access, local file reads, and clipboard writes are only used when you explicitly run the related publishing, preview, copy, AI, or multi-platform delivery features.
 
 ## 🔐 隐私与权限说明
 

--- a/main.js
+++ b/main.js
@@ -11584,10 +11584,7 @@ var require_wechatsync_results = __commonJS({
       { id: "sohufocus", name: "\u641C\u72D0\u7126\u70B9", homepage: "https://mp.focus.cn/fe/index.html#/info/draft", capabilities: ["article", "draft", "image_upload"] },
       { id: "x", name: "X (Twitter)", homepage: "https://x.com/compose/articles", capabilities: ["article", "draft", "image_upload"] },
       { id: "eastmoney", name: "\u4E1C\u65B9\u8D22\u5BCC", homepage: "https://mp.eastmoney.com", capabilities: ["article", "draft", "image_upload", "cover"] },
-      { id: "netease", name: "\u7F51\u6613\u53F7", homepage: "https://mp.163.com/#/article-publish", capabilities: ["article", "draft", "image_upload"] },
-      { id: "wordpress", name: "WordPress", homepage: "", capabilities: ["article", "draft", "image_upload"] },
-      { id: "typecho", name: "Typecho", homepage: "", capabilities: ["article", "draft", "image_upload"] },
-      { id: "zip-download", name: "Markdown \u538B\u7F29\u5305", homepage: "", capabilities: ["article"] }
+      { id: "netease", name: "\u7F51\u6613\u53F7", homepage: "https://mp.163.com/#/article-publish", capabilities: ["article", "draft", "image_upload"] }
     ];
     function getFallbackWechatsyncPlatforms2() {
       return FALLBACK_WECHATSYNC_PLATFORMS.map((platform) => ({ ...platform }));
@@ -14675,7 +14672,7 @@ var require_multi_platform = __commonJS({
           const authInfo = getWechatsyncPlatformStatusBadge2(platform, { bridgeConnected: isBridgeReady });
           const isSelected = isBridgeReady && modalSelectedPlatforms.has(platform.id);
           const row = platformListEl.createDiv({
-            cls: `wechat-multiplatform-platform ${isSelected ? `${authInfo.cls} is-selected` : ""}`
+            cls: `wechat-multiplatform-platform ${isSelected ? `${authInfo.cls} is-selected` : ""} ${!isBridgeReady ? "is-disabled" : ""}`.trim()
           });
           row.setAttribute("title", isSelected ? `${platform.name} \xB7 ${authInfo.text}` : platform.name);
           const checkbox = row.createEl("input");

--- a/services/wechatsync-results.js
+++ b/services/wechatsync-results.js
@@ -43,9 +43,6 @@ const FALLBACK_WECHATSYNC_PLATFORMS = [
   { id: 'x', name: 'X (Twitter)', homepage: 'https://x.com/compose/articles', capabilities: ['article', 'draft', 'image_upload'] },
   { id: 'eastmoney', name: '东方财富', homepage: 'https://mp.eastmoney.com', capabilities: ['article', 'draft', 'image_upload', 'cover'] },
   { id: 'netease', name: '网易号', homepage: 'https://mp.163.com/#/article-publish', capabilities: ['article', 'draft', 'image_upload'] },
-  { id: 'wordpress', name: 'WordPress', homepage: '', capabilities: ['article', 'draft', 'image_upload'] },
-  { id: 'typecho', name: 'Typecho', homepage: '', capabilities: ['article', 'draft', 'image_upload'] },
-  { id: 'zip-download', name: 'Markdown 压缩包', homepage: '', capabilities: ['article'] },
 ];
 
 function getFallbackWechatsyncPlatforms() {

--- a/styles.css
+++ b/styles.css
@@ -274,8 +274,6 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(120, 120, 128, 0.5) transparent;
   opacity: 0;
   visibility: hidden;
   transform: translateY(-20px);
@@ -1040,7 +1038,7 @@
   line-height: 1.65;
   white-space: pre-wrap;
   word-break: break-word;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-monospace), SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 .apple-converter-container.apple-converter-mobile .apple-ai-layout-area {
@@ -1086,8 +1084,6 @@
   /* 保持滚动可感知（移动端也允许惯性滚动） */
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(120, 120, 128, 0.5) transparent;
 
   /* 初始状态：向上隐去 (收起) */
   opacity: 0;
@@ -1267,7 +1263,7 @@
 
 /* 移除旧的设置面板样式，避免冲突 */
 .apple-settings-panel {
-  display: contents; /* 让子元素直接参与布局 */
+  display: block;
 }
 
 /* === 设置变更处理 === */
@@ -3154,8 +3150,6 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
   height: min(72vh, 720px);
   min-height: 560px;
   overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--apple-tertiary) 45%, transparent) transparent;
 }
 
 .wechat-publish-shell .modal-content::-webkit-scrollbar {
@@ -3377,8 +3371,6 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
   margin-top: 10px;
   overflow-y: auto;
   padding-right: 2px;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--apple-tertiary) 45%, transparent) transparent;
 }
 
 .wechat-multiplatform-list::-webkit-scrollbar {
@@ -3497,7 +3489,7 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
 .wechat-multiplatform-platform.is-unknown.is-selected::before { background: var(--apple-tertiary); }
 
 .wechat-multiplatform-platform input:disabled + label,
-.wechat-multiplatform-platform:has(input:disabled) label {
+.wechat-multiplatform-platform.is-disabled label {
   color: var(--apple-tertiary);
   cursor: default;
 }

--- a/tests/multi_platform_modal.test.js
+++ b/tests/multi_platform_modal.test.js
@@ -119,6 +119,19 @@ describe('AppleStyleView - showMultiPlatformSyncModal platform rows', () => {
     expect(row.classList.contains('is-ok')).toBe(true);
   });
 
+  it('marks platform rows disabled when the browser bridge is not ready', async () => {
+    const view = makeView({ selectedPlatforms: ['zhihu'] });
+    view.plugin.settings.multiPlatformSync.connection.status = 'disconnected';
+    await view.showMultiPlatformSyncModal();
+    const modal = modalCapture.getLastModal();
+    const row = findRow(modal, 'zhihu');
+    const checkbox = row.querySelector('input[type="checkbox"]');
+
+    expect(row.classList.contains('is-disabled')).toBe(true);
+    expect(row.classList.contains('is-selected')).toBe(false);
+    expect(checkbox.disabled).toBe(true);
+  });
+
   it('orders displayed platforms by authenticated state and featured platform order', async () => {
     const view = makeView({
       selectedPlatforms: ['xiaohongshu', 'zhihu', 'weibo', 'douban'],

--- a/tests/settings_ui_smoke.test.js
+++ b/tests/settings_ui_smoke.test.js
@@ -151,6 +151,24 @@ describe('AppleStyleSettingTab.display - smoke test', () => {
     expect(names).toContain('读取已选平台状态');
   });
 
+  it('does not expose hidden fallback-only platforms in the settings picker', () => {
+    const tab = renderTab(makePlugin({ multiPlatformSync: {
+      enabled: true,
+      port: 9527,
+      token: 'token',
+      supportedPlatforms: [],
+      selectedPlatforms: [],
+      connection: { status: 'failed', checkedAt: 123, platforms: [], capabilities: {}, message: '浏览器插件连接失败' },
+      recentTasks: [],
+    } }));
+    const platformIds = Array.from(tab.containerEl.querySelectorAll('.wechat-platform-chip input'))
+      .map((input) => input.value);
+
+    expect(platformIds).not.toContain('wordpress');
+    expect(platformIds).not.toContain('typecho');
+    expect(platformIds).not.toContain('zip-download');
+  });
+
   it('testing the bridge connection does not read or refresh platform auth state', async () => {
     const bridge = {
       start: vi.fn().mockResolvedValue({}),

--- a/tests/wechatsync_results.test.js
+++ b/tests/wechatsync_results.test.js
@@ -243,7 +243,9 @@ describe('Wechatsync result helpers', () => {
     expect(platformIds).toContain('xiaohongshu');
     expect(platformIds).toContain('toutiao');
     expect(platformIds).toContain('smzdm');
-    expect(platformIds).toContain('zip-download');
+    expect(platformIds).not.toContain('wordpress');
+    expect(platformIds).not.toContain('typecho');
+    expect(platformIds).not.toContain('zip-download');
     expect(platformIds).not.toContain('weixin');
     expect(platformIds).not.toContain('twitter');
     expect(platforms.every((platform) => Object.prototype.hasOwnProperty.call(platform, 'homepage'))).toBe(true);

--- a/views/publish-modal/multi-platform.js
+++ b/views/publish-modal/multi-platform.js
@@ -243,7 +243,7 @@ async function showMultiPlatformPublishModal(view, options = {}) {
       const authInfo = getWechatsyncPlatformStatusBadge(platform, { bridgeConnected: isBridgeReady });
       const isSelected = isBridgeReady && modalSelectedPlatforms.has(platform.id);
       const row = platformListEl.createDiv({
-        cls: `wechat-multiplatform-platform ${isSelected ? `${authInfo.cls} is-selected` : ''}`,
+        cls: `wechat-multiplatform-platform ${isSelected ? `${authInfo.cls} is-selected` : ''} ${!isBridgeReady ? 'is-disabled' : ''}`.trim(),
       });
       row.setAttribute('title', isSelected ? `${platform.name} · ${authInfo.text}` : platform.name);
       const checkbox = row.createEl('input');


### PR DESCRIPTION
## Summary
- expand English README privacy and permission notes for marketplace review
- replace low-compatibility CSS usage with safer selectors/properties
- remove WordPress, Typecho, and Markdown zip from the local Wechatsync fallback list
- add regression coverage for hidden fallback platforms and disabled platform rows

## Validation
- npm test -- --run
- npm run build
- npm run release:dryrun