### PR TITLE
Fix scan unsafe call warnings

### DIFF
--- a/input.js
+++ b/input.js
@@ -71,7 +71,7 @@
  * @typedef {{ updateConfig?: (values: Record<string, unknown>) => void, reinit?: () => void, initMarkdownIt?: () => Promise<void> }} ConverterRuntimeLike
  * @typedef {{ renderForPreview: (markdown: string, context: { sourcePath: string, settings: PluginSettingsLike }) => Promise<string> }} RenderPipelineLike
  * @typedef {{ updateAiToolbarState?: () => void, refreshAiLayoutPanel?: () => void }} ConverterViewRefreshLike
- * @typedef {PluginBaseLike & { settings: PluginSettingsLike, obsidianApi?: ObsidianApiLike, _wechatSyncBridgeService?: WechatSyncBridgeServiceLike, _wechatSyncBridgeCacheKey?: string, _lastSaveSettingsErrorAt?: number, openConverter: () => Promise<void>, getConverterView?: () => unknown, getWechatSyncBridgeService?: () => WechatSyncBridgeServiceLike, saveSettings: () => Promise<boolean>, getArticleLayoutState?: (sourcePath: string, selection?: AiLayoutSelectionLike | Record<string, unknown>) => AiLayoutStateLike | null, saveArticleLayoutState?: (sourcePath: string, nextState: AiLayoutStateLike | Record<string, unknown>, selection?: AiLayoutSelectionLike | Record<string, unknown>) => Promise<AiLayoutStateLike | null> }} AppleStylePluginLike
+ * @typedef {PluginBaseLike & { settings: PluginSettingsLike, obsidianApi?: ObsidianApiLike, _wechatSyncBridgeService?: WechatSyncBridgeServiceLike, _wechatSyncBridgeCacheKey?: string, _lastSaveSettingsErrorAt?: number, openConverter: () => Promise<void>, openExternalUrl?: (url: string) => boolean, getConverterView?: () => unknown, getWechatSyncBridgeService?: () => WechatSyncBridgeServiceLike, saveSettings: () => Promise<boolean>, getArticleLayoutState?: (sourcePath: string, selection?: AiLayoutSelectionLike | Record<string, unknown>) => AiLayoutStateLike | null, saveArticleLayoutState?: (sourcePath: string, nextState: AiLayoutStateLike | Record<string, unknown>, selection?: AiLayoutSelectionLike | Record<string, unknown>) => Promise<AiLayoutStateLike | null> }} AppleStylePluginLike
  * @typedef {{ settings?: PluginSettingsLike | Record<string, unknown> }} PluginWithSettingsLike
  * @typedef {{ setDestructive?: () => unknown, setWarning?: () => unknown }} ButtonCompatLike
  * @typedef {{ renderSettingsContent?: () => void, [key: string]: unknown }} SettingTabCompatLike
@@ -7604,7 +7604,10 @@ class AppleStyleSettingTab extends PluginSettingTab {
       cls: 'apple-settings-github-button',
     });
     starButton.onclick = () => {
-      this.plugin.openExternalUrl?.(GITHUB_REPOSITORY_URL);
+      const openExternalUrl = this.plugin.openExternalUrl;
+      if (typeof openExternalUrl === 'function') {
+        openExternalUrl.call(this.plugin, GITHUB_REPOSITORY_URL);
+      }
     };
   }
 
@@ -8763,8 +8766,13 @@ class AppleStylePlugin extends Plugin {
     const target = String(url || '').trim();
     if (!/^https?:\/\//i.test(target)) return false;
     const view = this.getConverterView?.();
-    if (view && typeof view.openExternalUrl === 'function') {
-      return view.openExternalUrl(target);
+    if (view && typeof view === 'object') {
+      const externalLinkView = /** @type {{ openExternalUrl?: unknown }} */ (view);
+      const openExternalUrl = externalLinkView.openExternalUrl;
+      if (typeof openExternalUrl === 'function') {
+        openExternalUrl.call(externalLinkView, target);
+        return true;
+      }
     }
     if (typeof window !== 'undefined' && typeof window.open === 'function') {
       window.open(target, '_blank', 'noopener');

--- a/views/settings/multi-platform-tab.js
+++ b/views/settings/multi-platform-tab.js
@@ -67,7 +67,7 @@ const LEGACY_SETTING_RENDER_KEY = ['dis', 'play'].join('');
  * @typedef {{ listSupportedPlatforms: (options?: Record<string, unknown>) => Promise<unknown>, getAuthSnapshot: (options?: Record<string, unknown>) => Promise<unknown>, start: () => Promise<unknown>, waitForConnection: (timeoutMs: number) => Promise<unknown>, health: (options?: Record<string, unknown>) => Promise<unknown>, getStatus?: () => Promise<unknown>, getDiagnostics?: () => unknown }} WechatBridgeLike
  * @typedef {{ multiPlatformSync?: unknown }} WechatPluginSettingsLike
  * @typedef {{ settings: WechatPluginSettingsLike, obsidianApi?: Partial<WechatObsidianApiLike>, activeView?: { openExternalUrl?: (url: string) => boolean }, openExternalUrl?: (url: string) => boolean, saveSettings: () => Promise<void>, startWechatSyncBridgeInBackground: (reason: string) => unknown, getWechatSyncBridgeService: () => WechatBridgeLike, _wechatSyncBridgeService?: { stop?: () => Promise<unknown> } }} WechatPluginLike
- * @typedef {{ plugin: WechatPluginLike, renderSettingsContent?: () => void, [key: string]: unknown }} WechatSettingsTabLike
+ * @typedef {{ plugin: WechatPluginLike, renderSettingsContent?: () => void, renderSettingsTabIntro?: (containerEl: WechatSettingsElement, description: string) => void, [key: string]: unknown }} WechatSettingsTabLike
  * @typedef {{ Setting: WechatSettingConstructor, Notice: WechatNoticeConstructor }} WechatObsidianApiLike
  * @typedef {{ color: string, path: string }} BrowserIconDef
  * @typedef {{ id: string, name: string, authKnown?: boolean, authStatus?: string, authenticated?: boolean }} WechatPlatformLike
@@ -299,8 +299,10 @@ function renderMultiPlatformSettingsTab(tab, containerEl, options = {}) {
   plugin.settings.multiPlatformSync = multiPlatformSettings;
   const isProLicensed = hasWechatSyncProLicense(multiPlatformSettings);
 
-  if (typeof tab.renderSettingsTabIntro === 'function') {
-    tab.renderSettingsTabIntro(
+  const renderSettingsTabIntro = tab.renderSettingsTabIntro;
+  if (typeof renderSettingsTabIntro === 'function') {
+    renderSettingsTabIntro.call(
+      tab,
       containerEl,
       '连接浏览器插件，并选择要保存草稿的内容平台。'
     );


### PR DESCRIPTION
## Summary
- Fix unsafe optional/dynamic function calls reported by scan review
- Add explicit type narrowing for GitHub Star and settings intro callbacks
- Rebuild generated plugin bundle

## Validation
- npm run scan:guard
- npm run build
- npm test -- tests/settings_ui_smoke.test.js --run