### PR TITLE
fix: refine AI layout and sticker panel UX

### DIFF
--- a/main.js
+++ b/main.js
@@ -68723,7 +68723,8 @@ var AiLayoutSchemaError = class extends Error {
 var AiLayoutTimeoutError = class extends Error {
   constructor(timeoutMs) {
     const seconds = Math.max(1, Math.round(Number(timeoutMs || 0) / 1e3));
-    super(`AI \u8BF7\u6C42\u8D85\u65F6\uFF08${seconds}s\uFF09`);
+    const suggestion = seconds >= 180 ? "\u5F53\u524D\u5DF2\u662F\u6700\u957F\u7B49\u5F85\u65F6\u95F4\uFF08180 \u79D2\uFF09\uFF0C\u53EF\u7F29\u77ED\u6587\u7AE0\u6216\u6539\u7528\u54CD\u5E94\u66F4\u5FEB\u7684\u6A21\u578B\u540E\u91CD\u8BD5\u3002" : "\u53EF\u5728\u63D2\u4EF6\u8BBE\u7F6E \u2192 AI \u7F16\u6392 \u2192 \u9AD8\u7EA7\u9009\u9879\u4E2D\u624B\u52A8\u8C03\u9AD8\u201CAI \u8BF7\u6C42\u8D85\u65F6\uFF08\u79D2\uFF09\u201D\uFF08\u6700\u9AD8 180 \u79D2\uFF09\u540E\u91CD\u8BD5\u3002";
+    super(`AI \u8BF7\u6C42\u8D85\u65F6\uFF08${seconds}s\uFF09\u3002\u672C\u6B21\u751F\u6210\u5DF2\u8FBE\u5230\u4F60\u8BBE\u7F6E\u7684\u7B49\u5F85\u65F6\u95F4\uFF0C${suggestion}`);
     this.name = "AiLayoutTimeoutError";
     this.code = "ai-layout-timeout";
     this.timeoutMs = Number(timeoutMs || 0);
@@ -70291,6 +70292,9 @@ function buildLayoutResult(rawLayout = {}, context = {}) {
 }
 
 // services/ai-layout/generation.js
+var AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS = 15e3;
+var AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS = 16;
+var AI_PROVIDER_CONNECTION_TEST_PROMPT = "Reply with OK only.";
 function extractJsonPayload(text) {
   const content = String(text || "").trim();
   if (!content)
@@ -70956,21 +70960,123 @@ async function generateArticleLayout({
     });
   }
 }
+var AiProviderConnectionTimeoutError = class extends Error {
+  constructor(timeoutMs) {
+    const seconds = Math.max(1, Math.round(Number(timeoutMs || 0) / 1e3));
+    super(`\u8FDE\u63A5\u6D4B\u8BD5\u8D85\u65F6\uFF08${seconds}s\uFF09\u3002\u63A5\u53E3\u53EF\u80FD\u54CD\u5E94\u8F83\u6162\uFF0C\u8BF7\u7A0D\u540E\u518D\u8BD5\u3002`);
+    this.name = "AiProviderConnectionTimeoutError";
+    this.code = "ai-provider-connection-timeout";
+    this.timeoutMs = Number(timeoutMs || 0);
+  }
+};
+async function ensureAiConnectionResponseOk(response) {
+  if (response.ok === true)
+    return;
+  const text = await response.text();
+  throw new Error(`AI \u8BF7\u6C42\u5931\u8D25 (${response.status || 0}): ${text || response.statusText || ""}`);
+}
+function hasAiConnectionResponse(providerKind, data) {
+  const source = toRecord(data);
+  if (providerKind === AI_PROVIDER_KINDS.OPENAI_COMPATIBLE) {
+    const choices = Array.isArray(source.choices) ? source.choices : [];
+    return choices.some((choice) => isRecord(toRecord(choice).message));
+  }
+  if (providerKind === AI_PROVIDER_KINDS.GEMINI) {
+    return Array.isArray(source.candidates) && source.candidates.length > 0;
+  }
+  if (providerKind === AI_PROVIDER_KINDS.ANTHROPIC) {
+    return Array.isArray(source.content) && source.content.length > 0;
+  }
+  return false;
+}
 async function testAiProviderConnection(provider, fetchImpl = getDefaultFetch()) {
-  var _a5, _b;
-  const result = await generateArticleLayout({
-    provider,
-    title: "\u8FDE\u63A5\u6D4B\u8BD5",
-    markdown: "\u8FD9\u662F\u4E00\u4E2A\u8FDE\u63A5\u6D4B\u8BD5\u3002\u8BF7\u8F93\u51FA\u6700\u5C0F\u53EF\u7528\u7684\u6559\u7A0B\u6392\u7248 JSON\u3002",
-    selection: {
-      layoutFamily: "tutorial-cards",
-      colorPalette: "tech-green"
-    },
-    imageRefs: [],
-    timeoutMs: 15e3,
-    fetchImpl
-  });
-  return !!((_b = (_a5 = result == null ? void 0 : result.layoutJson) == null ? void 0 : _a5.blocks) == null ? void 0 : _b.length);
+  const safeProvider = normalizeAiProvider(provider);
+  if (typeof fetchImpl !== "function")
+    throw new Error("\u5F53\u524D\u73AF\u5883\u4E0D\u652F\u6301 AI \u7F51\u7EDC\u8BF7\u6C42");
+  const controller = new AbortController();
+  const timer = setAiLayoutTimeout(
+    () => controller.abort(),
+    AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS
+  );
+  try {
+    let response;
+    let data;
+    switch (safeProvider.kind) {
+      case AI_PROVIDER_KINDS.OPENAI_COMPATIBLE: {
+        response = await fetchImpl(`${safeProvider.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${safeProvider.apiKey}`
+          },
+          body: JSON.stringify({
+            model: safeProvider.model,
+            temperature: 0,
+            max_tokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS,
+            messages: [{ role: "user", content: AI_PROVIDER_CONNECTION_TEST_PROMPT }]
+          }),
+          signal: controller.signal
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      case AI_PROVIDER_KINDS.GEMINI: {
+        const endpoint = `${safeProvider.baseUrl}/models/${encodeURIComponent(safeProvider.model)}:generateContent`;
+        response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-goog-api-key": safeProvider.apiKey
+          },
+          body: JSON.stringify({
+            contents: [{ role: "user", parts: [{ text: AI_PROVIDER_CONNECTION_TEST_PROMPT }] }],
+            generationConfig: {
+              temperature: 0,
+              maxOutputTokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS
+            }
+          }),
+          signal: controller.signal
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      case AI_PROVIDER_KINDS.ANTHROPIC: {
+        response = await fetchImpl(`${safeProvider.baseUrl}/messages`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": safeProvider.apiKey,
+            "anthropic-version": "2023-06-01"
+          },
+          body: JSON.stringify({
+            model: safeProvider.model,
+            max_tokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS,
+            temperature: 0,
+            messages: [{ role: "user", content: AI_PROVIDER_CONNECTION_TEST_PROMPT }]
+          }),
+          signal: controller.signal
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      default:
+        throw new Error(`\u6682\u4E0D\u652F\u6301\u7684 AI Provider \u7C7B\u578B: ${safeProvider.kind}`);
+    }
+    if (!hasAiConnectionResponse(safeProvider.kind, data)) {
+      throw new Error("\u6A21\u578B\u5DF2\u8FDE\u63A5\uFF0C\u4F46\u54CD\u5E94\u683C\u5F0F\u65E0\u6CD5\u8BC6\u522B");
+    }
+    return true;
+  } catch (error) {
+    if (controller.signal.aborted || isAbortError(error)) {
+      throw new AiProviderConnectionTimeoutError(AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS);
+    }
+    throw error;
+  } finally {
+    clearAiLayoutTimeout(timer);
+  }
 }
 
 // services/ai-layout/render.js
@@ -86340,7 +86446,11 @@ function renderStickerImageList(container, {
   onRemove,
   setIcon,
   emptyText = "\u8FD8\u6CA1\u6709\u53EF\u53D1\u5E03\u7684\u56FE\u7247\u3002",
-  focusKey = ""
+  focusKey = "",
+  collapsedRows = 0,
+  columnCount = 3,
+  expanded = false,
+  onExpandedChange
 } = {}) {
   const grid = container.createDiv({ cls: "sticker-image-list" });
   grid.setAttribute("role", "list");
@@ -86359,8 +86469,10 @@ function renderStickerImageList(container, {
     material: "\u7D20\u6750\u5E93",
     render: "\u6E32\u67D3"
   };
+  const cells = [];
   items.forEach((item, index) => {
     const cell = grid.createDiv({ cls: "sticker-image-list__item" });
+    cells.push(cell);
     cell.setAttribute("role", "listitem");
     cell.setAttribute("tabindex", "0");
     cell.setAttribute("draggable", "true");
@@ -86481,6 +86593,36 @@ function renderStickerImageList(container, {
       window.setTimeout(() => cell.focus(), 0);
     }
   });
+  const safeRows = Math.max(0, Math.floor(Number(collapsedRows) || 0));
+  const safeColumns = Math.max(1, Math.floor(Number(columnCount) || 3));
+  const collapsedItemLimit = safeRows * safeColumns;
+  const canCollapse = collapsedItemLimit > 0 && items.length > collapsedItemLimit;
+  if (canCollapse) {
+    const focusedIndex = focusKey ? items.findIndex((item) => item.key === focusKey) : -1;
+    let isExpanded = expanded === true || focusedIndex >= collapsedItemLimit;
+    if (isExpanded && expanded !== true)
+      onExpandedChange == null ? void 0 : onExpandedChange(true);
+    const toggleButton = container.createEl("button", {
+      cls: "sticker-image-list__toggle",
+      attr: { type: "button" }
+    });
+    const updateCollapsedState = () => {
+      grid.classList.toggle("is-collapsed", !isExpanded);
+      cells.forEach((cell, index) => {
+        cell.hidden = !isExpanded && index >= collapsedItemLimit;
+      });
+      toggleButton.setAttribute("aria-expanded", String(isExpanded));
+      toggleButton.setText(
+        isExpanded ? `\u6536\u8D77\u5230 ${safeRows} \u884C` : `\u5C55\u5F00\u5168\u90E8 ${items.length} \u5F20`
+      );
+    };
+    toggleButton.addEventListener("click", () => {
+      isExpanded = !isExpanded;
+      onExpandedChange == null ? void 0 : onExpandedChange(isExpanded);
+      updateCollapsedState();
+    });
+    updateCollapsedState();
+  }
   return grid;
 }
 
@@ -86497,6 +86639,7 @@ var stickerPreviewMethods = {
       * removedKeys: string[],
       * manualItems: object[],
       * undoItems: Array<{item:object,index:number,wasManual:boolean}>,
+      * imageListExpanded?: boolean,
       * objectUrls: Set<string>
       * }>} */
       selfRecord.stickerUiStates
@@ -86509,6 +86652,7 @@ var stickerPreviewMethods = {
         removedKeys: [],
         manualItems: [],
         undoItems: [],
+        imageListExpanded: false,
         objectUrls: /* @__PURE__ */ new Set()
       };
       states.set(key, state);
@@ -86653,10 +86797,6 @@ var stickerPreviewMethods = {
     const strippedParts = getStickerTransformParts(stickerData.removed);
     if (strippedParts.length > 0) {
       const notice = stickerContainer.createEl("div", { cls: "apple-sticker-notice-warning" });
-      const noticeIcon = notice.createEl("span", { cls: "apple-sticker-notice-icon" });
-      const noticeSetIcon = getObsidianSetIcon();
-      if (typeof noticeSetIcon === "function")
-        noticeSetIcon(noticeIcon, "info");
       const noticeContent = notice.createEl("div", { cls: "apple-sticker-notice-content" });
       noticeContent.createEl("span", { cls: "apple-sticker-notice-title", text: `\u5DF2\u8F6C\u6362\uFF1A${strippedParts.join("\u3001")}` });
       noticeContent.createEl("span", {
@@ -86707,9 +86847,6 @@ var stickerPreviewMethods = {
         text: `${stickerData.imageItems.length} / ${STICKER_MAX_IMAGES} \u5F20`
       });
       const hintLine = imagesSection.createEl("div", { cls: "apple-sticker-hint-line" });
-      const hintIcon = hintLine.createSpan({ cls: "apple-sticker-hint-icon" });
-      if (typeof setIcon === "function")
-        setIcon(hintIcon, "info");
       hintLine.createEl("span", {
         cls: "apple-sticker-hint-text",
         text: "\u987A\u5E8F\u5373\u6700\u7EC8\u53D1\u5E03\u987A\u5E8F\uFF1B\u6DFB\u52A0\u56FE\u7247\u8BF7\u6253\u5F00\u53D1\u5E03\u5F39\u7A97\uFF0C\u79FB\u9664\u4E0D\u4F1A\u6539\u52A8\u7B14\u8BB0\u3002"
@@ -86717,6 +86854,11 @@ var stickerPreviewMethods = {
       renderStickerImageList(imagesSection, {
         items: stickerData.imageItems,
         getDisplaySrc: (_, index) => stickerData.imageDisplaySources[index] || "",
+        collapsedRows: 2,
+        expanded: uiState.imageListExpanded === true,
+        onExpandedChange: (expanded) => {
+          uiState.imageListExpanded = expanded;
+        },
         setIcon,
         onMove: (fromIndex, toIndex, movedItem) => {
           uiState.order = moveStickerImageItem(
@@ -87698,6 +87840,9 @@ var aiLayoutPanelMethods = {
 };
 
 // views/converter/ai-layout-debug.js
+function isAiLayoutTimeoutMessage(errorText) {
+  return /^AI 请求超时（\d+s）/.test(String(errorText || "").trim());
+}
 var aiLayoutDebugMethods = {
   buildAiLayoutDebugJson(state) {
     if (!state)
@@ -88028,7 +88173,7 @@ var aiLayoutDebugMethods = {
       statusText = hasReusableLayout ? "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u5DF2\u4E3A\u4F60\u4FDD\u7559\u4E0A\u4E00\u7248\u7ED3\u679C\u3002" : "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u8BF7\u91CD\u8BD5\u6216\u68C0\u67E5 AI \u8BBE\u7F6E\u3002";
     } else if ((state == null ? void 0 : state.status) === "error") {
       badge = hasReusableLayout ? "\u5DF2\u4FDD\u7559\u4E0A\u4E00\u7248" : "\u751F\u6210\u5931\u8D25";
-      statusText = hasReusableLayout ? "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u5DF2\u4E3A\u4F60\u4FDD\u7559\u4E0A\u4E00\u7248\u7ED3\u679C\u3002" : "\u751F\u6210\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5\u6216\u68C0\u67E5 AI \u8BBE\u7F6E\u3002";
+      statusText = isAiLayoutTimeoutMessage(state.lastError) ? state.lastError : hasReusableLayout ? "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u5DF2\u4E3A\u4F60\u4FDD\u7559\u4E0A\u4E00\u7248\u7ED3\u679C\u3002" : "\u751F\u6210\u5931\u8D25\uFF0C\u8BF7\u91CD\u8BD5\u6216\u68C0\u67E5 AI \u8BBE\u7F6E\u3002";
     } else if (state && isStale) {
       if (canGenerateForSelection) {
         badge = "\u9700\u66F4\u65B0";
@@ -88039,7 +88184,7 @@ var aiLayoutDebugMethods = {
       }
     } else if (hasReusableLayout && hasLastAttemptFailure) {
       badge = "\u5DF2\u4FDD\u7559\u4E0A\u4E00\u7248";
-      statusText = "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u5DF2\u4E3A\u4F60\u4FDD\u7559\u4E0A\u4E00\u7248\u7ED3\u679C\u3002";
+      statusText = isAiLayoutTimeoutMessage(state.lastAttemptError) ? state.lastAttemptError : "\u8FD9\u6B21\u751F\u6210\u6CA1\u6709\u6210\u529F\uFF0C\u5DF2\u4E3A\u4F60\u4FDD\u7559\u4E0A\u4E00\u7248\u7ED3\u679C\u3002";
     } else if (state) {
       badge = hasApplied ? "\u5DF2\u5E94\u7528" : "\u53EF\u5E94\u7528";
       statusText = hasApplied ? "\u5DF2\u5E94\u7528\u5230\u9884\u89C8\u3002" : "\u53EF\u4EE5\u76F4\u63A5\u5E94\u7528\u5230\u9884\u89C8\u3002";
@@ -92254,7 +92399,7 @@ var aiSettingsMethods = {
           testBtn.textContent = "\u6D4B\u8BD5\u4E2D...";
           try {
             await testAiProviderConnection(provider, createObsidianFetchAdapter({ requestUrl: getObsidianRequestUrl(), request: getObsidianRequest() }));
-            new Notice(`\u2705 ${provider.name} \u8FDE\u63A5\u6210\u529F\uFF01`);
+            new Notice(`\u2705 ${provider.name} \u6A21\u578B\u53EF\u7528\uFF01`);
           } catch (error) {
             new Notice(`\u274C ${provider.name} \u8FDE\u63A5\u5931\u8D25: ${toReadableError5(error).message}`);
           }
@@ -92479,7 +92624,7 @@ var aiSettingsMethods = {
       testBtn.textContent = "\u6D4B\u8BD5\u4E2D...";
       try {
         await testAiProviderConnection(candidate, createObsidianFetchAdapter({ requestUrl: getObsidianRequestUrl(), request: getObsidianRequest() }));
-        new Notice("\u2705 AI Provider \u8FDE\u63A5\u6210\u529F\uFF01");
+        new Notice("\u2705 AI Provider \u6A21\u578B\u53EF\u7528\uFF01");
       } catch (error) {
         new Notice(`\u274C \u8FDE\u63A5\u5931\u8D25: ${toReadableError5(error).message}`);
       }

--- a/services/ai-layout/generation.js
+++ b/services/ai-layout/generation.js
@@ -9,7 +9,7 @@
 
 ## 输出
 
-输出 `extractJsonPayload`、`sanitizeJsonStringLiteralControls`、`inferBlockType`、`repairRawLayoutPayload`、`extractImageRefsFromHtml`、`buildLayoutMessages`、`readChatCompletionContent`、`readGeminiContent`、`readAnthropicContent`、`toPlainPromptFromMessages`，供 AI layout 入口和转换器面板调用。
+输出 AI 编排请求、轻量 Provider 连接检测、响应解析和 JSON 修复能力，供 AI layout 入口、设置页和转换器面板调用。
 
 ## 定位
 
@@ -76,6 +76,10 @@ import {
   toRecord,
   toSelectionRecord,
 } from './utils.js';
+
+const AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS = 15000;
+const AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS = 16;
+const AI_PROVIDER_CONNECTION_TEST_PROMPT = 'Reply with OK only.';
 
 /** @param {unknown} text @returns {string} */
 function extractJsonPayload(text) {
@@ -789,21 +793,133 @@ async function generateArticleLayout({
   }
 }
 
+class AiProviderConnectionTimeoutError extends Error {
+  constructor(timeoutMs) {
+    const seconds = Math.max(1, Math.round(Number(timeoutMs || 0) / 1000));
+    super(`连接测试超时（${seconds}s）。接口可能响应较慢，请稍后再试。`);
+    this.name = 'AiProviderConnectionTimeoutError';
+    this.code = 'ai-provider-connection-timeout';
+    this.timeoutMs = Number(timeoutMs || 0);
+  }
+}
+
+/** @param {FetchResponseLike} response @returns {Promise<void>} */
+async function ensureAiConnectionResponseOk(response) {
+  if (response.ok === true) return;
+  const text = await response.text();
+  throw new Error(`AI 请求失败 (${response.status || 0}): ${text || response.statusText || ''}`);
+}
+
+/** @param {string} providerKind @param {unknown} data @returns {boolean} */
+function hasAiConnectionResponse(providerKind, data) {
+  const source = toRecord(data);
+  if (providerKind === AI_PROVIDER_KINDS.OPENAI_COMPATIBLE) {
+    const choices = Array.isArray(source.choices) ? source.choices : [];
+    return choices.some((choice) => isRecord(toRecord(choice).message));
+  }
+  if (providerKind === AI_PROVIDER_KINDS.GEMINI) {
+    return Array.isArray(source.candidates) && source.candidates.length > 0;
+  }
+  if (providerKind === AI_PROVIDER_KINDS.ANTHROPIC) {
+    return Array.isArray(source.content) && source.content.length > 0;
+  }
+  return false;
+}
+
 /** @param {unknown} provider @param {FetchLike} [fetchImpl] @returns {Promise<boolean>} */
 async function testAiProviderConnection(provider, fetchImpl = getDefaultFetch()) {
-  const result = await generateArticleLayout({
-    provider,
-    title: '连接测试',
-    markdown: '这是一个连接测试。请输出最小可用的教程排版 JSON。',
-    selection: {
-      layoutFamily: 'tutorial-cards',
-      colorPalette: 'tech-green',
-    },
-    imageRefs: [],
-    timeoutMs: 15000,
-    fetchImpl,
-  });
-  return !!result?.layoutJson?.blocks?.length;
+  const safeProvider = normalizeAiProvider(provider);
+  if (typeof fetchImpl !== 'function') throw new Error('当前环境不支持 AI 网络请求');
+
+  const controller = new AbortController();
+  const timer = setAiLayoutTimeout(
+    () => controller.abort(),
+    AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS
+  );
+
+  try {
+    /** @type {FetchResponseLike} */
+    let response;
+    /** @type {unknown} */
+    let data;
+
+    switch (safeProvider.kind) {
+      case AI_PROVIDER_KINDS.OPENAI_COMPATIBLE: {
+        response = await fetchImpl(`${safeProvider.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${safeProvider.apiKey}`,
+          },
+          body: JSON.stringify({
+            model: safeProvider.model,
+            temperature: 0,
+            max_tokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS,
+            messages: [{ role: 'user', content: AI_PROVIDER_CONNECTION_TEST_PROMPT }],
+          }),
+          signal: controller.signal,
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      case AI_PROVIDER_KINDS.GEMINI: {
+        const endpoint = `${safeProvider.baseUrl}/models/${encodeURIComponent(safeProvider.model)}:generateContent`;
+        response = await fetchImpl(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': safeProvider.apiKey,
+          },
+          body: JSON.stringify({
+            contents: [{ role: 'user', parts: [{ text: AI_PROVIDER_CONNECTION_TEST_PROMPT }] }],
+            generationConfig: {
+              temperature: 0,
+              maxOutputTokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS,
+            },
+          }),
+          signal: controller.signal,
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      case AI_PROVIDER_KINDS.ANTHROPIC: {
+        response = await fetchImpl(`${safeProvider.baseUrl}/messages`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': safeProvider.apiKey,
+            'anthropic-version': '2023-06-01',
+          },
+          body: JSON.stringify({
+            model: safeProvider.model,
+            max_tokens: AI_PROVIDER_CONNECTION_TEST_MAX_TOKENS,
+            temperature: 0,
+            messages: [{ role: 'user', content: AI_PROVIDER_CONNECTION_TEST_PROMPT }],
+          }),
+          signal: controller.signal,
+        });
+        await ensureAiConnectionResponseOk(response);
+        data = await response.json();
+        break;
+      }
+      default:
+        throw new Error(`暂不支持的 AI Provider 类型: ${safeProvider.kind}`);
+    }
+
+    if (!hasAiConnectionResponse(safeProvider.kind, data)) {
+      throw new Error('模型已连接，但响应格式无法识别');
+    }
+    return true;
+  } catch (error) {
+    if (controller.signal.aborted || isAbortError(error)) {
+      throw new AiProviderConnectionTimeoutError(AI_PROVIDER_CONNECTION_TEST_TIMEOUT_MS);
+    }
+    throw error;
+  } finally {
+    clearAiLayoutTimeout(timer);
+  }
 }
 
 export {
@@ -821,5 +937,6 @@ export {
   isAbortError,
   parseAndRepairLayoutPayload,
   generateArticleLayout,
+  AiProviderConnectionTimeoutError,
   testAiProviderConnection,
 };

--- a/services/ai-layout/schema-validation.js
+++ b/services/ai-layout/schema-validation.js
@@ -140,7 +140,10 @@ class AiLayoutSchemaError extends Error {
 class AiLayoutTimeoutError extends Error {
   constructor(timeoutMs) {
     const seconds = Math.max(1, Math.round(Number(timeoutMs || 0) / 1000));
-    super(`AI 请求超时（${seconds}s）`);
+    const suggestion = seconds >= 180
+      ? '当前已是最长等待时间（180 秒），可缩短文章或改用响应更快的模型后重试。'
+      : '可在插件设置 → AI 编排 → 高级选项中手动调高“AI 请求超时（秒）”（最高 180 秒）后重试。';
+    super(`AI 请求超时（${seconds}s）。本次生成已达到你设置的等待时间，${suggestion}`);
     this.name = 'AiLayoutTimeoutError';
     this.code = 'ai-layout-timeout';
     this.timeoutMs = Number(timeoutMs || 0);

--- a/styles.css
+++ b/styles.css
@@ -438,7 +438,8 @@ AI layout 面板和生成结果的视觉样式
   --ai-layout-accent-soft: color-mix(in srgb, var(--ai-layout-accent) 10%, transparent);
   --ai-layout-accent-border: color-mix(in srgb, var(--ai-layout-accent) 72%, transparent);
   position: absolute;
-  top: 48px;
+  /* Header may occupy one or two rows. JS keeps this variable aligned with its real height. */
+  top: var(--apple-header-height, 98px);
   left: 0;
   right: 0;
   background: rgba(255, 255, 255, 0.72);
@@ -452,7 +453,10 @@ AI layout 面板和生成结果的视觉样式
   border-bottom-right-radius: 20px;
   z-index: 100;
   padding: 24px 12px 32px 12px;
-  max-height: 60%;
+  max-height: min(
+    60%,
+    calc(100% - var(--apple-header-height, 98px) - max(8px, env(safe-area-inset-bottom)))
+  );
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
@@ -546,7 +550,7 @@ AI layout 面板和生成结果的视觉样式
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   padding: 2px 16px 0;
   box-sizing: border-box;
 }
@@ -623,18 +627,19 @@ AI layout 面板和生成结果的视觉样式
 }
 
 .apple-ai-layout-header {
-  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .apple-ai-layout-title {
-  font-size: 18px;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--apple-primary);
-  line-height: 1.2;
+  line-height: 1.3;
 }
 
 .apple-ai-layout-subtitle {
-  margin-top: 6px;
   font-size: 12px;
   line-height: 1.5;
   color: var(--apple-secondary);
@@ -1232,7 +1237,6 @@ AI layout 面板和生成结果的视觉样式
 .apple-converter-container.apple-converter-mobile .apple-ai-layout-section {
   gap: 10px;
 }
-
 /*
 ## 核心功能
 
@@ -2611,28 +2615,15 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
    ======================================== */
 /* 图片列表标题下方的次级操作说明 */
 .apple-sticker-hint-line {
-  display: flex;
-  align-items: center;
-  gap: 5px;
   margin: -2px 0 10px;
-  padding: 0 0 0 20px;
+  padding: 0;
   font-size: 10.5px;
   color: var(--text-muted);
   opacity: 0.72;
 }
 
-.apple-sticker-hint-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 12px;
-  height: 12px;
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
 .apple-sticker-hint-text {
-  flex: 1;
+  display: block;
   text-align: left;
   line-height: 1.4;
 }
@@ -2692,17 +2683,6 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
   padding: 8px 10px;
   background: color-mix(in srgb, var(--text-warning) 10%, transparent);
   border-radius: 8px;
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-
-.apple-sticker-notice-icon {
-  font-size: 13px;
-  line-height: 1.2;
-  flex-shrink: 0;
-  margin-top: 1px;
-  opacity: 0.85;
 }
 
 .apple-sticker-notice-content {
@@ -2864,6 +2844,30 @@ input[type="range"].apple-slider:active::-webkit-slider-thumb {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
+}
+
+.sticker-image-list__toggle {
+  align-self: center;
+  min-height: 28px;
+  margin-top: 8px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--interactive-accent);
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.sticker-image-list__toggle:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+}
+
+.sticker-image-list__toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--interactive-accent) 45%, transparent);
+  outline-offset: 2px;
 }
 
 .sticker-image-list.is-empty {

--- a/styles/ai-layout.css
+++ b/styles/ai-layout.css
@@ -34,7 +34,8 @@ AI layout 面板和生成结果的视觉样式
   --ai-layout-accent-soft: color-mix(in srgb, var(--ai-layout-accent) 10%, transparent);
   --ai-layout-accent-border: color-mix(in srgb, var(--ai-layout-accent) 72%, transparent);
   position: absolute;
-  top: 48px;
+  /* Header may occupy one or two rows. JS keeps this variable aligned with its real height. */
+  top: var(--apple-header-height, 98px);
   left: 0;
   right: 0;
   background: rgba(255, 255, 255, 0.72);
@@ -48,7 +49,10 @@ AI layout 面板和生成结果的视觉样式
   border-bottom-right-radius: 20px;
   z-index: 100;
   padding: 24px 12px 32px 12px;
-  max-height: 60%;
+  max-height: min(
+    60%,
+    calc(100% - var(--apple-header-height, 98px) - max(8px, env(safe-area-inset-bottom)))
+  );
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
@@ -142,7 +146,7 @@ AI layout 面板和生成结果的视觉样式
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   padding: 2px 16px 0;
   box-sizing: border-box;
 }
@@ -219,18 +223,19 @@ AI layout 面板和生成结果的视觉样式
 }
 
 .apple-ai-layout-header {
-  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .apple-ai-layout-title {
-  font-size: 18px;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--apple-primary);
-  line-height: 1.2;
+  line-height: 1.3;
 }
 
 .apple-ai-layout-subtitle {
-  margin-top: 6px;
   font-size: 12px;
   line-height: 1.5;
   color: var(--apple-secondary);
@@ -828,4 +833,3 @@ AI layout 面板和生成结果的视觉样式
 .apple-converter-container.apple-converter-mobile .apple-ai-layout-section {
   gap: 10px;
 }
-

--- a/styles/sticker-preview.css
+++ b/styles/sticker-preview.css
@@ -30,28 +30,15 @@
    ======================================== */
 /* 图片列表标题下方的次级操作说明 */
 .apple-sticker-hint-line {
-  display: flex;
-  align-items: center;
-  gap: 5px;
   margin: -2px 0 10px;
-  padding: 0 0 0 20px;
+  padding: 0;
   font-size: 10.5px;
   color: var(--text-muted);
   opacity: 0.72;
 }
 
-.apple-sticker-hint-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 12px;
-  height: 12px;
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
 .apple-sticker-hint-text {
-  flex: 1;
+  display: block;
   text-align: left;
   line-height: 1.4;
 }
@@ -111,17 +98,6 @@
   padding: 8px 10px;
   background: color-mix(in srgb, var(--text-warning) 10%, transparent);
   border-radius: 8px;
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-
-.apple-sticker-notice-icon {
-  font-size: 13px;
-  line-height: 1.2;
-  flex-shrink: 0;
-  margin-top: 1px;
-  opacity: 0.85;
 }
 
 .apple-sticker-notice-content {
@@ -283,6 +259,30 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
+}
+
+.sticker-image-list__toggle {
+  align-self: center;
+  min-height: 28px;
+  margin-top: 8px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--interactive-accent);
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.sticker-image-list__toggle:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+}
+
+.sticker-image-list__toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--interactive-accent) 45%, transparent);
+  outline-offset: 2px;
 }
 
 .sticker-image-list.is-empty {

--- a/tests/ai_layout_service_generation.test.js
+++ b/tests/ai_layout_service_generation.test.js
@@ -28,11 +28,130 @@
 import { describe, expect, it, vi } from 'vitest';
 const {
   generateArticleLayout,
+  testAiProviderConnection,
   AiLayoutSchemaError,
   AiLayoutTimeoutError,
+  AiProviderConnectionTimeoutError,
 } = require('../services/ai-layout');
 
 describe('ai-layout service generation providers', () => {
+  it('should test OpenAI-compatible providers with a minimal text request', async () => {
+    const provider = {
+      name: 'DeepSeek',
+      kind: 'openai-compatible',
+      baseUrl: 'https://api.deepseek.com',
+      apiKey: 'secret',
+      model: 'deepseek-v4-flash',
+    };
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'OK' } }] }),
+    });
+
+    await expect(testAiProviderConnection(provider, fetchImpl)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchImpl.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(url).toBe('https://api.deepseek.com/chat/completions');
+    expect(body).toEqual({
+      model: 'deepseek-v4-flash',
+      temperature: 0,
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'Reply with OK only.' }],
+    });
+    expect(options.headers.Authorization).toBe('Bearer secret');
+    expect(body).not.toHaveProperty('selection');
+    expect(options.body).not.toContain('排版');
+  });
+
+  it('should test Gemini providers with a minimal text request', async () => {
+    const provider = {
+      name: 'Gemini',
+      kind: 'gemini',
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      apiKey: 'secret',
+      model: 'gemini-3-flash-preview',
+    };
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: 'OK' }] } }] }),
+    });
+
+    await expect(testAiProviderConnection(provider, fetchImpl)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchImpl.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(url).toBe('https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent');
+    expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'Reply with OK only.' }] }]);
+    expect(body.generationConfig).toEqual({ temperature: 0, maxOutputTokens: 16 });
+    expect(options.headers['x-goog-api-key']).toBe('secret');
+  });
+
+  it('should test Anthropic providers with a minimal text request', async () => {
+    const provider = {
+      name: 'Anthropic',
+      kind: 'anthropic',
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiKey: 'secret',
+      model: 'claude-3-5-haiku-latest',
+    };
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [{ type: 'text', text: 'OK' }] }),
+    });
+
+    await expect(testAiProviderConnection(provider, fetchImpl)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchImpl.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    expect(body).toEqual({
+      model: 'claude-3-5-haiku-latest',
+      max_tokens: 16,
+      temperature: 0,
+      messages: [{ role: 'user', content: 'Reply with OK only.' }],
+    });
+    expect(options.headers['x-api-key']).toBe('secret');
+  });
+
+  it('should distinguish connection-test timeout from the configured layout timeout', async () => {
+    vi.useFakeTimers();
+    const provider = {
+      name: '测试 Provider',
+      kind: 'openai-compatible',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'secret',
+      model: 'test-model',
+    };
+    const fetchImpl = (_url, options) => new Promise((_, reject) => {
+      options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    });
+
+    try {
+      const errorPromise = testAiProviderConnection(provider, fetchImpl).catch((error) => error);
+      await vi.advanceTimersByTimeAsync(15000);
+      const error = await errorPromise;
+      expect(error).toMatchObject({
+        name: 'AiProviderConnectionTimeoutError',
+        code: 'ai-provider-connection-timeout',
+        timeoutMs: 15000,
+        message: '连接测试超时（15s）。接口可能响应较慢，请稍后再试。',
+      });
+      expect(error).toBeInstanceOf(AiProviderConnectionTimeoutError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should explain the 180-second timeout without suggesting an unavailable higher setting', () => {
+    expect(new AiLayoutTimeoutError(180000).message).toBe(
+      'AI 请求超时（180s）。本次生成已达到你设置的等待时间，当前已是最长等待时间（180 秒），可缩短文章或改用响应更快的模型后重试。'
+    );
+  });
+
   it('should return generation meta and fallback info for sparse model output', async () => {
     const provider = {
       id: 'p1',
@@ -569,7 +688,7 @@ describe('ai-layout service generation providers', () => {
     })).rejects.toMatchObject({
       name: 'AiLayoutTimeoutError',
       code: 'ai-layout-timeout',
-      message: 'AI 请求超时（1s）',
+      message: 'AI 请求超时（1s）。本次生成已达到你设置的等待时间，可在插件设置 → AI 编排 → 高级选项中手动调高“AI 请求超时（秒）”（最高 180 秒）后重试。',
     });
 
     try {

--- a/tests/sticker_image_list.test.js
+++ b/tests/sticker_image_list.test.js
@@ -26,7 +26,9 @@
 */
 
 import { describe, expect, it } from 'vitest';
-import { moveStickerImageItem } from '../views/shared/sticker-image-list.js';
+import { moveStickerImageItem, renderStickerImageList } from '../views/shared/sticker-image-list.js';
+
+const { createObsidianLikeElement } = require('./helpers/obsidian-dom.js');
 
 describe('sticker image list ordering', () => {
   it('moves one item while preserving all other relative positions', () => {
@@ -38,5 +40,20 @@ describe('sticker image list ordering', () => {
     const result = moveStickerImageItem(source, -1, 1);
     expect(result).toEqual(source);
     expect(result).not.toBe(source);
+  });
+
+  it('does not collapse shared lists unless the caller opts in', () => {
+    const container = createObsidianLikeElement();
+    const items = Array.from({ length: 7 }, (_, index) => ({
+      key: `image-${index + 1}`,
+      source: 'body',
+      displaySrc: `app://local/image-${index + 1}.png`,
+    }));
+
+    renderStickerImageList(container, { items });
+
+    expect(container.querySelector('.sticker-image-list__toggle')).toBeNull();
+    expect(Array.from(container.querySelectorAll('.sticker-image-list__item')).every((cell) => !cell.hidden))
+      .toBe(true);
   });
 });

--- a/tests/styles_source_structure.test.js
+++ b/tests/styles_source_structure.test.js
@@ -86,4 +86,23 @@ describe('stylesheet source structure', () => {
     expect(stickerSettings).not.toContain('.apple-settings-sticker-header');
     expect(stickerSettings).not.toMatch(/\.apple-settings-sticker-wrapper\s+\.apple-setting-section/);
   });
+
+  it('positions the AI layout overlay below the measured preview header', () => {
+    const aiLayout = readProjectFile('styles/ai-layout.css');
+    const overlayRule = aiLayout.match(/\.apple-ai-layout-overlay\s*\{(?<body>[\s\S]*?)\n\}/)?.groups?.body || '';
+
+    expect(overlayRule).toContain('top: var(--apple-header-height');
+    expect(overlayRule).toMatch(/max-height:\s*min\([\s\S]*var\(--apple-header-height/);
+    expect(overlayRule).not.toMatch(/top:\s*48px/);
+  });
+
+  it('keeps the AI layout heading within the compact settings hierarchy', () => {
+    const aiLayout = readProjectFile('styles/ai-layout.css');
+    const titleRule = aiLayout.match(/\.apple-ai-layout-title\s*\{(?<body>[\s\S]*?)\n\}/)?.groups?.body || '';
+
+    expect(titleRule).toMatch(/font-size:\s*14px/);
+    expect(titleRule).toMatch(/font-weight:\s*600/);
+    expect(titleRule).not.toMatch(/font-size:\s*18px/);
+    expect(titleRule).not.toMatch(/font-weight:\s*800/);
+  });
 });

--- a/tests/view_ai_layout_state.test.js
+++ b/tests/view_ai_layout_state.test.js
@@ -879,6 +879,71 @@ describe('AppleStyleView AI layout state + debug', () => {
     expect(status.textContent.match(/生成失败/g)).toHaveLength(2);
   });
 
+  it('refreshAiLayoutPanel should show the manual timeout adjustment path in the status card', () => {
+    const timeoutMessage = 'AI 请求超时（120s）。本次生成已达到你设置的等待时间，可在插件设置 → AI 编排 → 高级选项中手动调高“AI 请求超时（秒）”（最高 180 秒）后重试。';
+    const timeoutState = {
+      version: 1,
+      updatedAt: Date.now(),
+      sourceHash: '123',
+      providerId: 'provider-1',
+      model: 'deepseek-chat',
+      stylePack: 'tech-green',
+      status: 'error',
+      lastError: timeoutMessage,
+      lastAttemptStatus: 'error',
+      lastAttemptError: timeoutMessage,
+      layoutJson: { blocks: [] },
+    };
+    const view = new AppleStyleView(null, {
+      settings: {
+        ai: {
+          enabled: true,
+          defaultStylePack: 'tech-green',
+          requestTimeoutMs: 120000,
+          defaultProviderId: 'provider-1',
+          providers: [{
+            id: 'provider-1',
+            name: 'DeepSeek',
+            kind: 'openai-compatible',
+            baseUrl: 'https://api.example.com/v1',
+            apiKey: 'secret',
+            model: 'deepseek-chat',
+            enabled: true,
+          }],
+          articleLayoutsByPath: { 'notes/demo.md': timeoutState },
+        },
+      },
+      saveSettings: vi.fn(),
+      getArticleLayoutState: vi.fn(() => timeoutState),
+    });
+    view.app = {
+      isMobile: false,
+      workspace: {
+        getActiveFile: vi.fn(() => ({ path: 'notes/demo.md', basename: 'demo' })),
+      },
+    };
+    view.theme = { update: vi.fn() };
+    view.converter = { updateConfig: vi.fn() };
+    view.lastResolvedSourcePath = 'notes/demo.md';
+    view.lastResolvedMarkdown = '# demo';
+    timeoutState.sourceHash = String(view.simpleHash('# demo'));
+    view.lastResolvedSourceHash = timeoutState.sourceHash;
+
+    global.AppleTheme = {
+      getThemeList: () => [{ value: 'github', label: '简约' }],
+      getColorList: () => [{ value: 'blue', color: '#0366d6' }],
+    };
+
+    const container = createObsidianLikeElement();
+    view.createSettingsPanel(container);
+    view.refreshAiLayoutPanel();
+
+    const statusText = container.querySelector('.apple-ai-layout-status-text')?.textContent || '';
+    expect(statusText).toContain('AI 请求超时（120s）');
+    expect(statusText).toContain('插件设置 → AI 编排 → 高级选项');
+    expect(statusText).toContain('手动调高');
+  });
+
   it('refreshAiLayoutPanel should show schema warnings even when generation succeeds', () => {
     const cachedState = {
       version: 1,

--- a/tests/view_sticker_mode.test.js
+++ b/tests/view_sticker_mode.test.js
@@ -101,6 +101,7 @@ describe('AppleStyleView - Sticker Mode Integration', () => {
       .toBe('已转换：代码块 1 处、表格 2 处');
     expect(view.previewContainer.querySelector('.apple-sticker-notice-desc')?.textContent)
       .toBe('内容已转换为适合贴图的纯文本，不会改动笔记原文。');
+    expect(view.previewContainer.querySelector('.apple-sticker-notice-icon')).toBeNull();
   });
 
   it('should collapse the image section into a blocking notice when no image exists', async () => {
@@ -162,5 +163,51 @@ describe('AppleStyleView - Sticker Mode Integration', () => {
     const gridIndex = children.indexOf(imageSection.querySelector('.sticker-image-list'));
     expect(headerIndex).toBeLessThan(hintIndex);
     expect(hintIndex).toBeLessThan(gridIndex);
+    expect(imageSection.querySelector('.apple-sticker-hint-icon')).toBeNull();
+  });
+
+  it('should keep the image list to two rows until the user expands it', async () => {
+    const leaf = { view: null };
+    const plugin = { settings: { wechatAccounts: [] } };
+    const view = new AppleStyleView(leaf, plugin);
+    const imageItems = Array.from({ length: 20 }, (_, index) => ({
+      key: `body:image-${index + 1}.png`,
+      source: 'body',
+      src: `image-${index + 1}.png`,
+      name: `image-${index + 1}.png`,
+    }));
+    const uiState = {
+      order: imageItems.map((item) => item.key),
+      removedKeys: [],
+      undoItems: [],
+      imageListExpanded: false,
+    };
+    view.previewMode = 'sticker';
+    view.previewContainer = createObsidianLikeElement();
+    view.buildStickerData = vi.fn().mockResolvedValue({
+      title: '测试',
+      content: '正文',
+      imageItems,
+      imageDisplaySources: imageItems.map((_, index) => `app://local/image-${index + 1}.png`),
+      sourcePath: 'test.md',
+      removed: [],
+    });
+    view.getStickerUiState = vi.fn().mockReturnValue(uiState);
+
+    await view.renderStickerPreview();
+
+    const cells = Array.from(view.previewContainer.querySelectorAll('.sticker-image-list__item'));
+    const toggle = view.previewContainer.querySelector('.sticker-image-list__toggle');
+    expect(cells).toHaveLength(20);
+    expect(cells.filter((cell) => !cell.hidden)).toHaveLength(6);
+    expect(toggle?.textContent).toBe('展开全部 20 张');
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+
+    toggle.click();
+
+    expect(cells.every((cell) => !cell.hidden)).toBe(true);
+    expect(toggle.textContent).toBe('收起到 2 行');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(uiState.imageListExpanded).toBe(true);
   });
 });

--- a/views/apple-style-view.js
+++ b/views/apple-style-view.js
@@ -70,6 +70,7 @@ class AppleStyleView extends ItemView {
      *   removedKeys: string[],
      *   manualItems: object[],
      *   undoItems: object[],
+     *   imageListExpanded?: boolean,
      *   objectUrls: Set<string>
      * }>}
      */

--- a/views/converter/ai-layout-debug.js
+++ b/views/converter/ai-layout-debug.js
@@ -49,6 +49,11 @@ import {
   getObsidianRequest,
 } from '../apple-style-view-shared.js';
 
+/** @param {unknown} errorText @returns {boolean} */
+function isAiLayoutTimeoutMessage(errorText) {
+  return /^AI 请求超时（\d+s）/.test(String(errorText || '').trim());
+}
+
 /** @type {AiLayoutDebugMethodsContract & ThisType<AppleStyleViewContract>} */
 export const aiLayoutDebugMethods = {
 buildAiLayoutDebugJson(state) {
@@ -418,9 +423,11 @@ refreshAiLayoutPanel() {
       : '这次生成没有成功，请重试或检查 AI 设置。';
   } else if (state?.status === 'error') {
     badge = hasReusableLayout ? '已保留上一版' : '生成失败';
-    statusText = hasReusableLayout
-      ? '这次生成没有成功，已为你保留上一版结果。'
-      : '生成失败，请重试或检查 AI 设置。';
+    statusText = isAiLayoutTimeoutMessage(state.lastError)
+      ? state.lastError
+      : (hasReusableLayout
+        ? '这次生成没有成功，已为你保留上一版结果。'
+        : '生成失败，请重试或检查 AI 设置。');
   } else if (state && isStale) {
     if (canGenerateForSelection) {
       badge = '需更新';
@@ -435,7 +442,9 @@ refreshAiLayoutPanel() {
     }
   } else if (hasReusableLayout && hasLastAttemptFailure) {
     badge = '已保留上一版';
-    statusText = '这次生成没有成功，已为你保留上一版结果。';
+    statusText = isAiLayoutTimeoutMessage(state.lastAttemptError)
+      ? state.lastAttemptError
+      : '这次生成没有成功，已为你保留上一版结果。';
   } else if (state) {
     badge = hasApplied ? '已应用' : '可应用';
     statusText = hasApplied

--- a/views/converter/sticker-preview.js
+++ b/views/converter/sticker-preview.js
@@ -61,6 +61,7 @@ getStickerUiState(filePath) {
    * removedKeys: string[],
    * manualItems: object[],
    * undoItems: Array<{item:object,index:number,wasManual:boolean}>,
+   * imageListExpanded?: boolean,
    * objectUrls: Set<string>
    * }>} */ (selfRecord.stickerUiStates);
   const key = filePath || '';
@@ -71,6 +72,7 @@ getStickerUiState(filePath) {
       removedKeys: [],
       manualItems: [],
       undoItems: [],
+      imageListExpanded: false,
       objectUrls: new Set(),
     };
     states.set(key, state);
@@ -238,9 +240,6 @@ async renderStickerPreview() {
   const strippedParts = getStickerTransformParts(stickerData.removed);
   if (strippedParts.length > 0) {
     const notice = stickerContainer.createEl('div', { cls: 'apple-sticker-notice-warning' });
-    const noticeIcon = notice.createEl('span', { cls: 'apple-sticker-notice-icon' });
-    const noticeSetIcon = getObsidianSetIcon();
-    if (typeof noticeSetIcon === 'function') noticeSetIcon(noticeIcon, 'info');
     const noticeContent = notice.createEl('div', { cls: 'apple-sticker-notice-content' });
     noticeContent.createEl('span', { cls: 'apple-sticker-notice-title', text: `已转换：${strippedParts.join('、')}` });
     noticeContent.createEl('span', {
@@ -295,8 +294,6 @@ async renderStickerPreview() {
     });
 
     const hintLine = imagesSection.createEl('div', { cls: 'apple-sticker-hint-line' });
-    const hintIcon = hintLine.createSpan({ cls: 'apple-sticker-hint-icon' });
-    if (typeof setIcon === 'function') setIcon(hintIcon, 'info');
     hintLine.createEl('span', {
       cls: 'apple-sticker-hint-text',
       text: '顺序即最终发布顺序；添加图片请打开发布弹窗，移除不会改动笔记。'
@@ -305,6 +302,11 @@ async renderStickerPreview() {
     renderStickerImageList(imagesSection, {
       items: stickerData.imageItems,
       getDisplaySrc: (_, index) => stickerData.imageDisplaySources[index] || '',
+      collapsedRows: 2,
+      expanded: uiState.imageListExpanded === true,
+      onExpandedChange: (expanded) => {
+        uiState.imageListExpanded = expanded;
+      },
       setIcon,
       onMove: (fromIndex, toIndex, movedItem) => {
         uiState.order = moveStickerImageItem(

--- a/views/settings/ai-section.js
+++ b/views/settings/ai-section.js
@@ -183,7 +183,7 @@ const aiSettingsMethods = {
           testBtn.textContent = '测试中...';
           try {
             await testAiProviderConnection(provider, createObsidianFetchAdapter({ requestUrl: getObsidianRequestUrl(), request: getObsidianRequest() }));
-            new Notice(`✅ ${provider.name} 连接成功！`);
+            new Notice(`✅ ${provider.name} 模型可用！`);
           } catch (error) {
             new Notice(`❌ ${provider.name} 连接失败: ${toReadableError(error).message}`);
           }
@@ -411,7 +411,7 @@ const aiSettingsMethods = {
       testBtn.textContent = '测试中...';
       try {
         await testAiProviderConnection(candidate, createObsidianFetchAdapter({ requestUrl: getObsidianRequestUrl(), request: getObsidianRequest() }));
-        new Notice('✅ AI Provider 连接成功！');
+        new Notice('✅ AI Provider 模型可用！');
       } catch (error) {
         new Notice(`❌ 连接失败: ${toReadableError(error).message}`);
       }

--- a/views/shared/sticker-image-list.js
+++ b/views/shared/sticker-image-list.js
@@ -9,7 +9,7 @@
 
 ## 输出
 
-输出可访问的图片网格 DOM；导出纯函数 `moveStickerImageItem` 供状态更新和测试复用。
+输出可访问的图片网格 DOM，并支持调用方按行数启用展开/收起；导出纯函数 `moveStickerImageItem` 供状态更新和测试复用。
 
 ## 定位
 
@@ -62,6 +62,10 @@ function moveStickerImageItem(items, fromIndex, toIndex) {
  * @param {(element:HTMLElement,icon:string)=>void} [options.setIcon]
  * @param {string} [options.emptyText]
  * @param {string} [options.focusKey]
+ * @param {number} [options.collapsedRows]
+ * @param {number} [options.columnCount]
+ * @param {boolean} [options.expanded]
+ * @param {(expanded:boolean)=>void} [options.onExpandedChange]
  * @returns {ObsidianElementLike}
  */
 function renderStickerImageList(container, {
@@ -72,6 +76,10 @@ function renderStickerImageList(container, {
   setIcon,
   emptyText = '还没有可发布的图片。',
   focusKey = '',
+  collapsedRows = 0,
+  columnCount = 3,
+  expanded = false,
+  onExpandedChange,
 } = {}) {
   const grid = container.createDiv({ cls: 'sticker-image-list' });
   grid.setAttribute('role', 'list');
@@ -92,8 +100,11 @@ function renderStickerImageList(container, {
     render: '渲染',
   };
 
+  const cells = [];
+
   items.forEach((item, index) => {
     const cell = grid.createDiv({ cls: 'sticker-image-list__item' });
+    cells.push(cell);
     cell.setAttribute('role', 'listitem');
     cell.setAttribute('tabindex', '0');
     cell.setAttribute('draggable', 'true');
@@ -207,6 +218,44 @@ function renderStickerImageList(container, {
       window.setTimeout(() => cell.focus(), 0);
     }
   });
+
+  const safeRows = Math.max(0, Math.floor(Number(collapsedRows) || 0));
+  const safeColumns = Math.max(1, Math.floor(Number(columnCount) || 3));
+  const collapsedItemLimit = safeRows * safeColumns;
+  const canCollapse = collapsedItemLimit > 0 && items.length > collapsedItemLimit;
+
+  if (canCollapse) {
+    const focusedIndex = focusKey
+      ? items.findIndex((item) => item.key === focusKey)
+      : -1;
+    let isExpanded = expanded === true || focusedIndex >= collapsedItemLimit;
+    if (isExpanded && expanded !== true) onExpandedChange?.(true);
+
+    const toggleButton = container.createEl('button', {
+      cls: 'sticker-image-list__toggle',
+      attr: { type: 'button' },
+    });
+
+    const updateCollapsedState = () => {
+      grid.classList.toggle('is-collapsed', !isExpanded);
+      cells.forEach((cell, index) => {
+        cell.hidden = !isExpanded && index >= collapsedItemLimit;
+      });
+      toggleButton.setAttribute('aria-expanded', String(isExpanded));
+      toggleButton.setText(
+        isExpanded
+          ? `收起到 ${safeRows} 行`
+          : `展开全部 ${items.length} 张`
+      );
+    };
+
+    toggleButton.addEventListener('click', () => {
+      isExpanded = !isExpanded;
+      onExpandedChange?.(isExpanded);
+      updateCollapsedState();
+    });
+    updateCollapsedState();
+  }
 
   return grid;
 }


### PR DESCRIPTION
## Summary

- Make AI 编排 connection tests perform a lightweight, single-request model availability check with a 16-token cap.
- Keep formal AI layout timeout fully controlled by the user and show a clear manual adjustment suggestion on timeout.
- Reduce the AI 编排 panel heading to the same compact hierarchy as style settings and fix the overlay spacing.
- Remove redundant hint icons from sticker preview notices.
- Collapse sticker image previews to two rows by default, with an explicit expand/collapse control; the publish modal still shows the full list.

## Root cause

The AI connection test was generating a complete layout JSON, so slower providers such as DeepSeek could approach the fixed test window even when the model itself was available. The AI overlay heading also used a larger display treatment than the existing settings surface. Long sticker image lists were rendered without a compact presentation state, which pushed the text preview below the fold.

## Validation

- 63 targeted regression tests passed.
- Production build and generated-artifact reproducibility checks passed.
- Obsidian scan-risk guard, style/runtime sync checks, and `git diff --check` passed.
- Verified in a real Obsidian session: AI heading hierarchy, sticker icon removal, two-row collapse, expand/collapse behavior, and full-list publish modal behavior.

No automatic timeout adjustment or automatic retry was added.
