### PR TITLE
fix: convert WebP images to PNG before WeChat upload

### DIFF
--- a/docs/basic/backend-structure.md
+++ b/docs/basic/backend-structure.md
@@ -10,7 +10,7 @@
 - `services/dependency-loader.js` 加载嵌入式运行时依赖，避免 Obsidian 环境中动态依赖失配。
 - `services/native-renderer.js`、`services/obsidian-triplet-renderer.js` 和 serializer 模块承接 native-only 渲染方向。
 - `services/sticker-extractor.js` 与 `services/markdown-cleaner.js` 负责微信贴图数据提取和纯文本降级：图片嵌入与非图片嵌入分流，代码、表格、公式、脚注等复杂结构优先保留可读语义，无法可靠展开的结构使用明确占位。
-- `services/wechat-*` 模块负责微信 token、素材、草稿、HTML 清洗、媒体上传、同步上下文和失败反馈。
+- `services/wechat-*` 模块负责微信 token、素材、草稿、HTML 清洗、媒体上传、同步上下文和失败反馈；上传边界会在内存中把 WebP 统一转换为 PNG，不修改 Markdown 或图床原文件。
 - `services/feishu-*` 模块负责飞书文档同步、媒体处理、设置、API 调用和 Mermaid 远程渲染策略。
 - `services/wechatsync-*` 模块负责桌面端浏览器发布助手桥接、平台设置、结果回传和任务状态；模块本身必须可在移动端安全加载，桌面专用 Node API 只能在平台守卫后动态获取。
 - `server/` 是可部署的微信代理辅助服务，不是插件运行的必需组件。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,7 @@ export default [
       "services/wechat-draft-cache.js",
       "services/wechat-api.js",
       "services/wechat-api-utils.js",
+      "services/wechat-image-transcoder.js",
       "services/wechat-html-cleaner.js",
       "services/wechat-media.js",
       "services/wechat-sync.js",

--- a/main.js
+++ b/main.js
@@ -81872,6 +81872,114 @@ async function pMap(array, mapper, concurrency = 3) {
   return Promise.all(results);
 }
 
+// services/wechat-image-transcoder.js
+var WEBP_HEADER_SIZE = 12;
+var PNG_MIME_TYPE = "image/png";
+function normalizeMimeType(value) {
+  return String(value || "").split(";")[0].trim().toLowerCase();
+}
+function getErrorMessage4(error) {
+  if (error instanceof Error)
+    return error.message;
+  if (error && typeof error === "object" && typeof error["message"] === "string") {
+    return error["message"];
+  }
+  return String(error || "\u672A\u77E5\u9519\u8BEF");
+}
+async function readBlobArrayBuffer(blob) {
+  if (typeof (blob == null ? void 0 : blob.arrayBuffer) === "function") {
+    return await blob.arrayBuffer();
+  }
+  if (typeof FileReader !== "function") {
+    throw new Error("\u5F53\u524D\u73AF\u5883\u65E0\u6CD5\u8BFB\u53D6\u56FE\u7247\u6570\u636E");
+  }
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+      } else {
+        reject(new Error("\u8BFB\u53D6\u56FE\u7247\u6570\u636E\u5931\u8D25"));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error("\u8BFB\u53D6\u56FE\u7247\u6570\u636E\u5931\u8D25"));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+async function isWebpBlob(blob) {
+  if (!blob)
+    return false;
+  if (normalizeMimeType(blob.type) === "image/webp")
+    return true;
+  if (typeof blob.slice !== "function")
+    return false;
+  const headerBuffer = await readBlobArrayBuffer(blob.slice(0, WEBP_HEADER_SIZE));
+  const bytes = new Uint8Array(headerBuffer);
+  if (bytes.length < WEBP_HEADER_SIZE)
+    return false;
+  return bytes[0] === 82 && bytes[1] === 73 && bytes[2] === 70 && bytes[3] === 70 && bytes[8] === 87 && bytes[9] === 69 && bytes[10] === 66 && bytes[11] === 80;
+}
+function canvasToPngBlob(canvas) {
+  if (typeof (canvas == null ? void 0 : canvas.toBlob) !== "function") {
+    return Promise.reject(new Error("\u5F53\u524D\u73AF\u5883\u4E0D\u652F\u6301 Canvas PNG \u8F6C\u6362"));
+  }
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Canvas \u672A\u751F\u6210 PNG \u6570\u636E"));
+        return;
+      }
+      resolve(normalizeMimeType(blob.type) === PNG_MIME_TYPE ? blob : new Blob([blob], { type: PNG_MIME_TYPE }));
+    }, PNG_MIME_TYPE);
+  });
+}
+function loadImage(objectUrl, options) {
+  return new Promise((resolve, reject) => {
+    const image = typeof options.createImage === "function" ? options.createImage() : typeof Image === "function" ? new Image() : null;
+    if (!image) {
+      reject(new Error("\u5F53\u524D\u73AF\u5883\u65E0\u6CD5\u89E3\u7801 WebP \u56FE\u7247"));
+      return;
+    }
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("WebP \u56FE\u7247\u89E3\u7801\u5931\u8D25"));
+    image.src = objectUrl;
+  });
+}
+async function normalizeWechatUploadImageBlob(blob, options = {}) {
+  if (!await isWebpBlob(blob))
+    return blob;
+  const activeDocument = options.document || getActiveDocument();
+  const createObjectUrl = options.createObjectUrl || (typeof URL !== "undefined" && typeof URL.createObjectURL === "function" ? (value) => URL.createObjectURL(value) : null);
+  const revokeObjectUrl = options.revokeObjectUrl || (typeof URL !== "undefined" && typeof URL.revokeObjectURL === "function" ? (value) => URL.revokeObjectURL(value) : null);
+  if (!activeDocument || typeof createObjectUrl !== "function") {
+    throw new Error("WebP \u8F6C PNG \u5931\u8D25\uFF1A\u5F53\u524D\u73AF\u5883\u7F3A\u5C11\u56FE\u7247\u8F6C\u6362\u80FD\u529B");
+  }
+  let objectUrl = "";
+  try {
+    objectUrl = createObjectUrl(blob);
+    const image = await loadImage(objectUrl, options);
+    const width = Number(image.naturalWidth || image.width) || 0;
+    const height = Number(image.naturalHeight || image.height) || 0;
+    if (width <= 0 || height <= 0) {
+      throw new Error("\u65E0\u6CD5\u83B7\u53D6 WebP \u56FE\u7247\u5C3A\u5BF8");
+    }
+    const canvas = activeDocument.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context)
+      throw new Error("\u65E0\u6CD5\u521B\u5EFA Canvas 2D \u4E0A\u4E0B\u6587");
+    context.drawImage(image, 0, 0, width, height);
+    return await canvasToPngBlob(canvas);
+  } catch (error) {
+    throw new Error(`WebP \u8F6C PNG \u5931\u8D25\uFF1A${getErrorMessage4(error)}`);
+  } finally {
+    if (objectUrl && typeof revokeObjectUrl === "function") {
+      revokeObjectUrl(objectUrl);
+    }
+  }
+}
+
 // services/wechat-api.js
 function toReadableError4(error) {
   if (error instanceof Error)
@@ -82320,12 +82428,14 @@ var WechatAPI = class {
    * @returns {Promise<Record<string, unknown>>}
    */
   async uploadMultipart(url, blob, fieldName) {
+    if (this.proxyUrl)
+      this.validateProxyUrl(this.proxyUrl);
+    const uploadBlob = await normalizeWechatUploadImageBlob(blob);
     return this.requestWithRetry(async () => {
-      const mimeType = blob.type || "image/jpeg";
+      const mimeType = uploadBlob.type || "image/jpeg";
       const ext = mimeType.includes("gif") ? "gif" : mimeType.includes("png") ? "png" : "jpg";
       if (this.proxyUrl) {
-        this.validateProxyUrl(this.proxyUrl);
-        const base64Data = await readBlobAsBase64Payload(blob);
+        const base64Data = await readBlobAsBase64Payload(uploadBlob);
         const headers = { "Content-Type": "application/json" };
         if (this.clientId) {
           headers["X-Client-Id"] = this.clientId;
@@ -82360,7 +82470,7 @@ var WechatAPI = class {
         }
       } else {
         const boundary = "----ObsidianWechatConverterBoundary" + Math.random().toString(36).substring(2);
-        const arrayBuffer = await blob.arrayBuffer();
+        const arrayBuffer = await uploadBlob.arrayBuffer();
         const bytes = new Uint8Array(arrayBuffer);
         let header = `--${boundary}\r
 `;

--- a/services/wechat-api.js
+++ b/services/wechat-api.js
@@ -17,7 +17,7 @@
 
 ## 依赖
 
-关键依赖：`./obsidian-compat.js`、`./concurrency.js`、`./sticker-constants.js`。
+关键依赖：`./obsidian-compat.js`、`./concurrency.js`、`./sticker-constants.js`、`./wechat-image-transcoder.js`。
 
 ## 维护规则
 
@@ -28,6 +28,7 @@
 import { getObsidianRequestUrl } from './obsidian-compat.js';
 import { sleep } from './concurrency.js';
 import { STICKER_MAX_IMAGES } from './sticker-constants.js';
+import { normalizeWechatUploadImageBlob } from './wechat-image-transcoder.js';
 
 /** @param {unknown} error @returns {ReadableErrorLike} */
 function toReadableError(error) {
@@ -573,17 +574,18 @@ export class WechatAPI {
    * @returns {Promise<Record<string, unknown>>}
    */
   async uploadMultipart(url, blob, fieldName) {
+    if (this.proxyUrl) this.validateProxyUrl(this.proxyUrl);
+    const uploadBlob = await normalizeWechatUploadImageBlob(blob);
+
     return this.requestWithRetry(async () => {
 
       // 获取真实的 MIME 类型和文件扩展名
-      const mimeType = blob.type || 'image/jpeg';
+      const mimeType = uploadBlob.type || 'image/jpeg';
       const ext = mimeType.includes('gif') ? 'gif' : mimeType.includes('png') ? 'png' : 'jpg';
 
       if (this.proxyUrl) {
-        this.validateProxyUrl(this.proxyUrl);
-
         // 通过代理发送：将文件转为 base64 (使用 FileReader 提升性能)
-        const base64Data = await readBlobAsBase64Payload(blob);
+        const base64Data = await readBlobAsBase64Payload(uploadBlob);
 
         const headers = { 'Content-Type': 'application/json' };
         if (this.clientId) {
@@ -619,7 +621,7 @@ export class WechatAPI {
       } else {
         // 直连：原有逻辑
         const boundary = '----ObsidianWechatConverterBoundary' + Math.random().toString(36).substring(2);
-        const arrayBuffer = await blob.arrayBuffer();
+        const arrayBuffer = await uploadBlob.arrayBuffer();
         const bytes = new Uint8Array(arrayBuffer);
 
         let header = `--${boundary}\r\n`;

--- a/services/wechat-image-transcoder.js
+++ b/services/wechat-image-transcoder.js
@@ -1,0 +1,198 @@
+/*
+## 核心功能
+
+在微信公众号素材上传前识别 WebP 图片，并按原始尺寸转换为 PNG Blob。
+
+## 输入
+
+接收待上传的图片 Blob，以及测试或特殊运行环境可选注入的 DOM/图片解码依赖。
+
+## 输出
+
+输出可直接上传微信的图片 Blob；非 WebP 保持原对象，WebP 统一输出 `image/png`。
+
+## 定位
+
+位于 services/，属于微信媒体上传前的格式兼容层；不修改 Markdown、预览 DOM 或图床资源。
+
+## 依赖
+
+关键依赖：`./dom-utils.js`。
+
+## 维护规则
+
+- 转码只发生在内存中，不写回源文件或 Vault。
+- WebP 以 MIME 或 RIFF/WEBP 文件头任一命中为准。
+- 保持原始像素尺寸，不在本层增加压缩或缩放策略。
+*/
+
+import { getActiveDocument } from './dom-utils.js';
+
+const WEBP_HEADER_SIZE = 12;
+const PNG_MIME_TYPE = 'image/png';
+
+/**
+ * @typedef {{
+ *   document?: Document | null,
+ *   createImage?: (() => HTMLImageElement) | null,
+ *   createObjectUrl?: ((blob: Blob) => string) | null,
+ *   revokeObjectUrl?: ((url: string) => void) | null,
+ * }} WebpTranscodeOptions
+ */
+
+/** @param {unknown} value */
+function normalizeMimeType(value) {
+  return String(value || '').split(';')[0].trim().toLowerCase();
+}
+
+/** @param {unknown} error */
+function getErrorMessage(error) {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && typeof error['message'] === 'string') {
+    return error['message'];
+  }
+  return String(error || '未知错误');
+}
+
+/**
+ * @param {Blob} blob
+ * @returns {Promise<ArrayBuffer>}
+ */
+async function readBlobArrayBuffer(blob) {
+  if (typeof blob?.arrayBuffer === 'function') {
+    return await blob.arrayBuffer();
+  }
+
+  if (typeof FileReader !== 'function') {
+    throw new Error('当前环境无法读取图片数据');
+  }
+
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer) {
+        resolve(reader.result);
+      } else {
+        reject(new Error('读取图片数据失败'));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error('读取图片数据失败'));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+/**
+ * @param {Blob | null | undefined} blob
+ * @returns {Promise<boolean>}
+ */
+export async function isWebpBlob(blob) {
+  if (!blob) return false;
+  if (normalizeMimeType(blob.type) === 'image/webp') return true;
+  if (typeof blob.slice !== 'function') return false;
+
+  const headerBuffer = await readBlobArrayBuffer(blob.slice(0, WEBP_HEADER_SIZE));
+  const bytes = new Uint8Array(headerBuffer);
+  if (bytes.length < WEBP_HEADER_SIZE) return false;
+
+  return bytes[0] === 0x52
+    && bytes[1] === 0x49
+    && bytes[2] === 0x46
+    && bytes[3] === 0x46
+    && bytes[8] === 0x57
+    && bytes[9] === 0x45
+    && bytes[10] === 0x42
+    && bytes[11] === 0x50;
+}
+
+/**
+ * @param {HTMLCanvasElement} canvas
+ * @returns {Promise<Blob>}
+ */
+function canvasToPngBlob(canvas) {
+  if (typeof canvas?.toBlob !== 'function') {
+    return Promise.reject(new Error('当前环境不支持 Canvas PNG 转换'));
+  }
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Canvas 未生成 PNG 数据'));
+        return;
+      }
+      resolve(normalizeMimeType(blob.type) === PNG_MIME_TYPE
+        ? blob
+        : new Blob([blob], { type: PNG_MIME_TYPE }));
+    }, PNG_MIME_TYPE);
+  });
+}
+
+/**
+ * @param {string} objectUrl
+ * @param {WebpTranscodeOptions} options
+ * @returns {Promise<HTMLImageElement>}
+ */
+function loadImage(objectUrl, options) {
+  return new Promise((resolve, reject) => {
+    const image = typeof options.createImage === 'function'
+      ? options.createImage()
+      : (typeof Image === 'function' ? new Image() : null);
+
+    if (!image) {
+      reject(new Error('当前环境无法解码 WebP 图片'));
+      return;
+    }
+
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('WebP 图片解码失败'));
+    image.src = objectUrl;
+  });
+}
+
+/**
+ * @param {Blob} blob
+ * @param {WebpTranscodeOptions} [options]
+ * @returns {Promise<Blob>}
+ */
+export async function normalizeWechatUploadImageBlob(blob, options = {}) {
+  if (!(await isWebpBlob(blob))) return blob;
+
+  const activeDocument = options.document || getActiveDocument();
+  const createObjectUrl = options.createObjectUrl
+    || (typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function'
+      ? (value) => URL.createObjectURL(value)
+      : null);
+  const revokeObjectUrl = options.revokeObjectUrl
+    || (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function'
+      ? (value) => URL.revokeObjectURL(value)
+      : null);
+
+  if (!activeDocument || typeof createObjectUrl !== 'function') {
+    throw new Error('WebP 转 PNG 失败：当前环境缺少图片转换能力');
+  }
+
+  let objectUrl = '';
+  try {
+    objectUrl = createObjectUrl(blob);
+    const image = await loadImage(objectUrl, options);
+    const width = Number(image.naturalWidth || image.width) || 0;
+    const height = Number(image.naturalHeight || image.height) || 0;
+    if (width <= 0 || height <= 0) {
+      throw new Error('无法获取 WebP 图片尺寸');
+    }
+
+    const canvas = activeDocument.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('无法创建 Canvas 2D 上下文');
+
+    context.drawImage(image, 0, 0, width, height);
+    return await canvasToPngBlob(canvas);
+  } catch (error) {
+    throw new Error(`WebP 转 PNG 失败：${getErrorMessage(error)}`);
+  } finally {
+    if (objectUrl && typeof revokeObjectUrl === 'function') {
+      revokeObjectUrl(objectUrl);
+    }
+  }
+}

--- a/tests/wechat_api.test.js
+++ b/tests/wechat_api.test.js
@@ -100,6 +100,67 @@ describe('WechatAPI - Upload & MIME Logic', () => {
     expect(body.fileData).toBe('ZmFrZS1pbWFnZS1kYXRh');
   });
 
+  it('should transcode WebP to PNG at the shared WeChat upload boundary', async () => {
+    const originalImage = window.Image;
+    const originalCreateObjectUrl = window.URL.createObjectURL;
+    const originalRevokeObjectUrl = window.URL.revokeObjectURL;
+    const createElement = document.createElement.bind(document);
+    const drawImage = vi.fn();
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage })),
+      toBlob: vi.fn((callback, mimeType) => callback(new Blob(['png-data'], { type: mimeType }))),
+    };
+
+    class MockImage {
+      constructor() {
+        this.naturalWidth = 640;
+        this.naturalHeight = 360;
+        this.onload = null;
+        this.onerror = null;
+      }
+
+      set src(value) {
+        this.currentSrc = value;
+        this.onload?.();
+      }
+    }
+
+    window.Image = MockImage;
+    window.URL.createObjectURL = vi.fn(() => 'blob:wechat-webp');
+    window.URL.revokeObjectURL = vi.fn();
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      if (tagName === 'canvas') return canvas;
+      return createElement(tagName, options);
+    });
+
+    try {
+      const api = new WechatAPI('appid', 'secret', 'https://proxy.com');
+      const webpBytes = new Uint8Array([
+        0x52, 0x49, 0x46, 0x46,
+        0x04, 0x00, 0x00, 0x00,
+        0x57, 0x45, 0x42, 0x50,
+      ]);
+      const source = new Blob([webpBytes], { type: 'image/webp' });
+      obsidianMock.requestUrl.mockResolvedValue({ json: { url: 'https://mmbiz.qpic.cn/png' } });
+
+      await api.uploadMultipart('https://api.weixin.qq.com/upload', source, 'media');
+
+      const body = JSON.parse(obsidianMock.requestUrl.mock.calls[0][0].body);
+      expect(body.mimeType).toBe('image/png');
+      expect(body.fileName).toBe('image.png');
+      expect(canvas.width).toBe(640);
+      expect(canvas.height).toBe(360);
+      expect(drawImage).toHaveBeenCalledTimes(1);
+    } finally {
+      createElementSpy.mockRestore();
+      window.Image = originalImage;
+      window.URL.createObjectURL = originalCreateObjectUrl;
+      window.URL.revokeObjectURL = originalRevokeObjectUrl;
+    }
+  });
+
   // === Task B: Remote MIME Parsing ===
   it('should detect MIME type from headers for http images', async () => {
     const view = new AppleStyleView(null, null);

--- a/tests/wechat_image_transcoder.test.js
+++ b/tests/wechat_image_transcoder.test.js
@@ -1,0 +1,141 @@
+/*
+## 核心功能
+
+覆盖微信图片上传前 WebP 转 PNG 服务的格式识别、尺寸保持、透传和失败反馈。
+
+## 输入
+
+接收 WebP/PNG Blob，以及 mock 的图片解码、Canvas 和 Object URL 能力。
+
+## 输出
+
+输出 PNG Blob、原始非 WebP Blob或明确错误断言，保护微信媒体兼容链路。
+
+## 定位
+
+位于 tests/，是微信媒体格式兼容的单元测试。
+
+## 依赖
+
+关键依赖：Vitest、`../services/wechat-image-transcoder.js`。
+
+## 维护规则
+
+- 覆盖 MIME 与 RIFF/WEBP 文件头两种识别路径。
+- 转码测试必须验证原始像素尺寸和 Object URL 清理。
+*/
+
+import { describe, expect, it, vi } from 'vitest';
+
+const {
+  isWebpBlob,
+  normalizeWechatUploadImageBlob,
+} = require('../services/wechat-image-transcoder.js');
+
+function createWebpBytes() {
+  return new Uint8Array([
+    0x52, 0x49, 0x46, 0x46,
+    0x04, 0x00, 0x00, 0x00,
+    0x57, 0x45, 0x42, 0x50,
+    0x56, 0x50, 0x38, 0x20,
+  ]);
+}
+
+function createTranscodeHarness({ failDecode = false, pngBlob = new Blob(['png'], { type: 'image/png' }) } = {}) {
+  const drawImage = vi.fn();
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => ({ drawImage })),
+    toBlob: vi.fn((callback, mimeType) => callback(
+      pngBlob ? new Blob([pngBlob], { type: mimeType }) : null
+    )),
+  };
+  const document = {
+    createElement: vi.fn((tagName) => {
+      if (tagName !== 'canvas') throw new Error(`Unexpected element: ${tagName}`);
+      return canvas;
+    }),
+  };
+  const createObjectUrl = vi.fn(() => 'blob:webp-source');
+  const revokeObjectUrl = vi.fn();
+  const image = {
+    naturalWidth: 1280,
+    naturalHeight: 720,
+    width: 1280,
+    height: 720,
+    onload: null,
+    onerror: null,
+    set src(value) {
+      this.currentSrc = value;
+      if (failDecode) this.onerror?.();
+      else this.onload?.();
+    },
+  };
+
+  return {
+    canvas,
+    drawImage,
+    image,
+    options: {
+      document,
+      createImage: () => image,
+      createObjectUrl,
+      revokeObjectUrl,
+    },
+    createObjectUrl,
+    revokeObjectUrl,
+  };
+}
+
+describe('wechat image transcoder', () => {
+  it('converts image/webp to PNG while preserving pixel dimensions', async () => {
+    const source = new Blob([createWebpBytes()], { type: 'image/webp' });
+    const harness = createTranscodeHarness();
+
+    const result = await normalizeWechatUploadImageBlob(source, harness.options);
+
+    expect(result.type).toBe('image/png');
+    expect(harness.canvas.width).toBe(1280);
+    expect(harness.canvas.height).toBe(720);
+    expect(harness.drawImage).toHaveBeenCalledWith(harness.image, 0, 0, 1280, 720);
+    expect(harness.createObjectUrl).toHaveBeenCalledWith(source);
+    expect(harness.revokeObjectUrl).toHaveBeenCalledWith('blob:webp-source');
+  });
+
+  it('detects WebP by RIFF/WEBP header when MIME is incorrect', async () => {
+    const source = new Blob([createWebpBytes()], { type: 'application/octet-stream' });
+
+    expect(await isWebpBlob(source)).toBe(true);
+
+    const result = await normalizeWechatUploadImageBlob(source, createTranscodeHarness().options);
+    expect(result.type).toBe('image/png');
+  });
+
+  it('passes non-WebP images through without decoding', async () => {
+    const source = new Blob(['png'], { type: 'image/png' });
+    const createImage = vi.fn();
+
+    const result = await normalizeWechatUploadImageBlob(source, { createImage });
+
+    expect(result).toBe(source);
+    expect(createImage).not.toHaveBeenCalled();
+  });
+
+  it('reports a clear error and revokes the Object URL when WebP decoding fails', async () => {
+    const source = new Blob([createWebpBytes()], { type: 'image/webp' });
+    const harness = createTranscodeHarness({ failDecode: true });
+
+    await expect(normalizeWechatUploadImageBlob(source, harness.options))
+      .rejects.toThrow('WebP 转 PNG 失败：WebP 图片解码失败');
+    expect(harness.revokeObjectUrl).toHaveBeenCalledWith('blob:webp-source');
+  });
+
+  it('reports a clear error when Canvas cannot produce a PNG Blob', async () => {
+    const source = new Blob([createWebpBytes()], { type: 'image/webp' });
+    const harness = createTranscodeHarness({ pngBlob: null });
+
+    await expect(normalizeWechatUploadImageBlob(source, harness.options))
+      .rejects.toThrow('WebP 转 PNG 失败：Canvas 未生成 PNG 数据');
+  });
+});


### PR DESCRIPTION
## Summary

- detect WebP uploads by both MIME type and RIFF/WEBP file signature
- convert WebP images to PNG at their original pixel dimensions before the shared WeChat upload boundary
- apply the same behavior to article images, cover images, and sticker-mode uploads
- keep PNG, JPEG, GIF, source Markdown, and remote image-host files unchanged

## Why

WeChat uploads do not reliably accept WebP images, while image hosts commonly serve blog assets as WebP and may sometimes return an incorrect MIME type. The existing upload path derived a filename from the reported MIME type but still sent the original bytes, so changing an extension could not make a WebP payload compatible.

This change performs a real in-memory Canvas conversion and reports a clear `WebP 转 PNG 失败` error if decoding or PNG generation fails.

## Impact

- no new user setting or workflow change
- no compression or resizing before upload
- no mutation of the active Markdown note, vault image, or image-host resource
- generated `main.js` is rebuilt from the source changes

## Validation

- `npm run release:dryrun`
- targeted Vitest coverage for MIME/header detection, dimension preservation, passthrough behavior, shared upload integration, and failure reporting
- `npm run build`
- `npm run scan:guard`
- `npm run check:build-artifacts`

## Draft follow-up

- [ ] Confirm one real WebP article in an Obsidian-to-WeChat draft sync
